### PR TITLE
site: rename "beta" branch to "testing"

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -44,7 +44,7 @@ make update GLUON_RELEASE="${gluon_ref}+${version}" GLUON_TARGET="${target}" GLU
 make        GLUON_RELEASE="${gluon_ref}+${version}" GLUON_TARGET="${target}" GLUON_BRANCH=stable -j${jobs} V=99
 
 # Create manifests
-for branch in experimental beta stable; do
+for branch in experimental testing stable; do
     make manifest GLUON_RELEASE="${gluon_ref}+${version}" GLUON_BRANCH=${branch} GLUON_AUTOUPDATER_BRANCH=${branch}
 done
 popd

--- a/site.conf
+++ b/site.conf
@@ -58,16 +58,16 @@
                                         '24b25027ebe9c76ece1db0e562755f852b35c92e5a68f63f831bb4e6ad7b4bef', -- FFDON-mgk
                                 },
                         },
-                        beta = {
-                                name = 'beta',
+                        testing = {
+                                name = 'testing',
                                 mirrors = {
-                                        'http://firmware.ffmuc.net/ffdon/beta/sysupgrade',
-                                        'http://5.1.66.255/ffdon/beta/sysupgrade',
-                                        'http://185.150.99.255/ffdon/beta/sysupgrade',
-                                        'http://[2001:678:e68:f000::]/ffdon/beta/sysupgrade',
-                                        'http://[2001:678:ed0:f000::]/ffdon/beta/sysupgrade',
-                                        'http://1.updates.services.ffdon/ffdonV2/beta/sysupgrade',
-                                        'http://firmware2.ffdon.de/ffdonV2/beta/sysupgrade',
+                                        'http://firmware.ffmuc.net/ffdon/testing/sysupgrade',
+                                        'http://5.1.66.255/ffdon/testing/sysupgrade',
+                                        'http://185.150.99.255/ffdon/testing/sysupgrade',
+                                        'http://[2001:678:e68:f000::]/ffdon/testing/sysupgrade',
+                                        'http://[2001:678:ed0:f000::]/ffdon/testing/sysupgrade',
+                                        'http://1.updates.services.ffdon/ffdonV2/testing/sysupgrade',
+                                        'http://firmware2.ffdon.de/ffdonV2/testing/sysupgrade',
                                 },
                                 good_signatures = 2,
                                 pubkeys = {


### PR DESCRIPTION
No clients left on "beta" branch. Renaming can be done without migration.