### PR TITLE
domains: rename ffdon_test to ffmuc_ffdon_test

### DIFF
--- a/domains/ffmuc_ffdon_test.conf
+++ b/domains/ffmuc_ffdon_test.conf
@@ -1,6 +1,6 @@
 {
     domain_names = {
-        ffdon_test = 'Freifunk Donau-Ries Test'
+        ffmuc_ffdon_test = 'Freifunk Donau-Ries Test'
     },
     domain_seed = 'b9d58035a5a2256627a813ee9d10ebdbf53bbac562fddf240c28ed2becf4c0ec',
 

--- a/site.conf
+++ b/site.conf
@@ -2,7 +2,7 @@
         hostname_prefix = 'ffdon-',
         site_name = 'Freifunk Donau-Ries',
         site_code = 'ffdon',
-        default_domain = 'ffdon_test',
+        default_domain = 'ffmuc_ffdon_test',
 
         mesh_on_lan = true,
 


### PR DESCRIPTION
Renaming ffdon_test to allow easier gateway integration for initial gateway migration testing.