### PR TITLE
site: use improved SSID changer

### DIFF
--- a/domains/ffdon_baeumenheim.conf
+++ b/domains/ffdon_baeumenheim.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_donauwoerth.conf
+++ b/domains/ffdon_donauwoerth.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_harburg.conf
+++ b/domains/ffdon_harburg.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_monheim.conf
+++ b/domains/ffdon_monheim.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_noerdlingen.conf
+++ b/domains/ffdon_noerdlingen.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_oettingen.conf
+++ b/domains/ffdon_oettingen.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_rain.conf
+++ b/domains/ffdon_rain.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_umland.conf
+++ b/domains/ffdon_umland.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffdon_wemding.conf
+++ b/domains/ffdon_wemding.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/domains/ffmuc_ffdon_test.conf
+++ b/domains/ffmuc_ffdon_test.conf
@@ -46,4 +46,8 @@
             },
         },
     },
+
+    ssid_changer = {
+        enabled = true,
+    },
 }

--- a/modules
+++ b/modules
@@ -1,5 +1,8 @@
-GLUON_SITE_FEEDS='ffms'
+GLUON_SITE_FEEDS='ssidchanger ffms'
 
 PACKAGES_FFMS_REPO=https://github.com/freifunkMUC/packages-ffms.git
 PACKAGES_FFMS_COMMIT=c5fe8936983c9aaf9fed07e0a1c045761b7092b5
 PACKAGES_FFMS_BRANCH=v2019.1.x
+
+PACKAGES_SSIDCHANGER_REPO=https://github.com/Freifunk-Nord/gluon-ssid-changer.git
+PACKAGES_SSIDCHANGER_COMMIT=f266b9e6328f97354f3b8777d1111ad044be9be5

--- a/site.conf
+++ b/site.conf
@@ -108,4 +108,14 @@
                         },
                 },
         },
+
+        ssid_changer = {
+                enabled = false,                -- do not enable by default. Only some domains will enable it
+                switch_timeframe = 2,           -- defines how long it will record the gateway-connectivity. Only if the gateway is not
+                                                -- reachable during at least half the checks within switch_timeframe minutes, the SSID will be changed
+                first = 2,                      -- the first few minutes directly after reboot within which an Offline-SSID always may be activated
+                prefix = 'FF_Offline_',
+                suffix = 'nodename',            -- generate the SSID with either 'nodename', 'mac' or to use only the prefix: 'none'
+                tq_limit_enabled = false,       -- if false, the offline SSID will only be set if there is no gateway reacheable
+        },
 }


### PR DESCRIPTION
the new SSID changer works with Batman V and has support for both 2.4 GHz and 2.4+5 GHz devices.

It can also be enabled/disabled per site.